### PR TITLE
emailConfirmation bugfix

### DIFF
--- a/src/main/java/com/example/tt_nsk/controller/AuthController.java
+++ b/src/main/java/com/example/tt_nsk/controller/AuthController.java
@@ -66,8 +66,13 @@ public class AuthController {
         model.addAttribute("username", username);
 
         String confirmationCode = userService.getConfirmationCode();
-        emailService.sendConfirmationCode(confirmationCode, userDto.getEmail());
-//        System.out.println("Confirmation code! " + confirmationCode);
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                emailService.sendConfirmationCode(confirmationCode, userDto.getEmail());
+            }
+        }).start();
 
         userService.generateConfirmationCode(thisUser, confirmationCode);
         model.addAttribute("id", thisUser.getId());
@@ -76,13 +81,11 @@ public class AuthController {
     }
 
     @PostMapping("/confirmation")
-    public String handleConfirmationForm (String code, Model model) {
+    public String handleConfirmationForm(String code, Model model) {
         model.addAttribute("code", code);
         System.out.println("code: " + code);
-        ConfirmationCode confirmationCodeBy_id = confirmationCodeDao.findConfirmationCodeByAccountUser_Id(thisUser.getId());
 
-//        System.out.println(confirmationCodeBy_id.getCode() + " + from model: " + code);
-//        System.out.println("from model: " + code);
+        ConfirmationCode confirmationCodeBy_id = confirmationCodeDao.findConfirmationCodeByAccountUser_Id(thisUser.getId());
 
         if (confirmationCodeBy_id.equals(code)) {
             System.out.println(confirmationCodeBy_id.equals(code));
@@ -95,9 +98,17 @@ public class AuthController {
 
             return "redirect:/auth/login";
         }
-//        System.out.println(!code.equals(confirmationCodeBy_id.toString()));
-//        return "auth/registration-confirmation";
 
         return "auth/invalid-confirmation";
+    }
+
+    @PostMapping("/changeUsername")
+    public String changeUsername() {
+        thisUser.setUsername(String.format("%s_id%s_%s",
+                thisUser.getUsername(), thisUser.getId(), "deleted"));
+        userService.update(thisUser);
+        userService.deleteById(thisUser.getId());
+
+        return "redirect:/auth/login";
     }
 }

--- a/src/main/resources/templates/auth/invalid-confirmation.html
+++ b/src/main/resources/templates/auth/invalid-confirmation.html
@@ -23,7 +23,7 @@
         <form th:action="@{/auth/confirmation}"
               th:object="${confirmationCode}" method="post" class="form-horizontal">
 
-            <h4>Неправильный код подтверждения</h4>
+            <h6>Неправильный код подтверждения</h6>
             <br>
 
             <div style="margin-bottom: 25px" class="input-group">
@@ -35,16 +35,15 @@
                 <div class="col-sm-6 controls">
                     <button type="submit" class="btn btn-primary">Confirm</button>
                 </div>
-                <br>
-
-                <p>Для возврата к авторизации перейдите по <a th:href="@{/auth/login}">ссылке</a></p>
-
-                <foot>
-                    <br>
-                    <br>
-                </foot>
             </div>
             <div th:replace="~{common/footer :: footerBlock}"/>
+        </form>
+
+        <br>
+        <h6>Возврат к окну авторизации</h6>
+        <br>
+        <form th:action="@{/auth/changeUsername}" method="post">
+            <button type="submit" class="btn btn-primary">Return</button>
         </form>
 </body>
 </html>

--- a/src/main/resources/templates/auth/registration-confirmation.html
+++ b/src/main/resources/templates/auth/registration-confirmation.html
@@ -32,16 +32,15 @@
                 <div class="col-sm-6 controls">
                     <button type="submit" class="btn btn-primary">Confirm</button>
                 </div>
-                <br>
-
-                <p>Для возврата к авторизации перейдите по <a th:href="@{/auth/login}">ссылке</a></p>
-
-                <foot>
-                    <br>
-                    <br>
-                </foot>
             </div>
             <div th:replace="~{common/footer :: footerBlock}"/>
+        </form>
+
+        <br>
+        <h6>Возврат к окну авторизации</h6>
+        <br>
+        <form th:action="@{/auth/changeUsername}" method="post">
+            <button type="submit" class="btn btn-primary">Return</button>
         </form>
 </body>
 </html>


### PR DESCRIPTION
1. <b>Пофиксил баг</b>: если не ввести проверочный код, а перейти в окно авторизации по ссылке, то введенный никнейм "блокировался" и повисал в бд мертвым грузом
2. <b>Поменял форму ввода проверочного кода</b>: убрал ссылку, добавил кнопку
3. <b>Изменил отправку email</b>: теперь процесс отправки запускается в отдельном потоке (не уверен, можно ли так делать), и пользователь дожидается кода в окне его ввода, а не на экране регистрации